### PR TITLE
Allow changing InputHistoryProvider

### DIFF
--- a/src/Typin/Typin.Modes.Interactive/InteractiveModeOptions.cs
+++ b/src/Typin/Typin.Modes.Interactive/InteractiveModeOptions.cs
@@ -37,7 +37,7 @@
         /// <summary>
         /// Command input history.
         /// </summary>
-        public IInputHistoryProvider InputHistory { get; } = new InputHistoryProvider();
+        public IInputHistoryProvider InputHistory { get; set; } = new InputHistoryProvider();
 
         /// <summary>
         /// User defined shortcuts.


### PR DESCRIPTION
I want to add an IInputHistoryProvider that saves history to a text file, but I need to be able to change it first.